### PR TITLE
chore: Fix the build and push stage

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Git
         run: |
@@ -62,7 +62,9 @@ jobs:
     needs: update
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3   
+        uses: actions/checkout@v4
+        with:
+          ref: main   
 
       - name: pack the project
         run: |


### PR DESCRIPTION
When the build and push job runs, the checkout uses the commit of the
trigger rather than the latest unless explicitly directed to do so. This
change specifies main as the branch to check out after the update flow
has made the required change
