### PR TITLE
ci: harden release workflow security

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
+          token: ${{ secrets.TRIVY_CHOCOLATEY_DEPLOY_TOKEN }}
           persist-credentials: false
 
       - name: Set up Git
@@ -59,6 +60,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
+          token: ${{ secrets.TRIVY_CHOCOLATEY_DEPLOY_TOKEN }}
           ref: main
           persist-credentials: false
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          persist-credentials: false
+          token: ${{ secrets.TRIVY_CHOCOLATEY_DEPLOY_TOKEN }}
+          persist-credentials: true
 
       - name: Set up Git
         run: |
@@ -43,12 +44,11 @@ jobs:
 
       - name: Commit and push changes
         env:
-          TRIVY_CHOCOLATEY_DEPLOY_TOKEN: ${{ secrets.TRIVY_CHOCOLATEY_DEPLOY_TOKEN }}
           GIT_REF_NAME: ${{ github.ref_name }}
         run: |
           git add trivy.nuspec tools/chocolateyinstall.ps1
           git commit -m "Update package to latest version" || echo "No changes to commit"
-          git push "https://x-access-token:${TRIVY_CHOCOLATEY_DEPLOY_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "HEAD:${GIT_REF_NAME}"
+          git push origin "HEAD:${GIT_REF_NAME}"
 
     # on windows latest, build and push the package to chocolatey.org and myget.org
   build-and-push:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,12 +8,12 @@ on:
         required: false
         default: ''
 
+permissions: {}
+
 jobs:
   # run the update script on ubuntu and push the changes to main branch
   update:
     runs-on: ubuntu-2404-2core
-    permissions:
-      contents: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -54,8 +54,6 @@ jobs:
   build-and-push:
     runs-on: windows-latest
     needs: update
-    permissions:
-      contents: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
-          token: ${{ secrets.TRIVY_CHOCOLATEY_DEPLOY_TOKEN }}
           persist-credentials: false
 
       - name: Set up Git

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,8 @@ on:
         required: false
         default: ''
 
-permissions: {}
+permissions:
+  contents: read
 
 jobs:
   # run the update script on ubuntu and push the changes to main branch
@@ -16,7 +17,7 @@ jobs:
     runs-on: ubuntu-2404-2core
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 
@@ -47,7 +48,7 @@ jobs:
         run: |
           git add trivy.nuspec tools/chocolateyinstall.ps1
           git commit -m "Update package to latest version" || echo "No changes to commit"
-          git push "https://x-access-token:${TRIVY_CHOCOLATEY_DEPLOY_TOKEN}@github.com/${{ github.repository }}.git" "HEAD:${GIT_REF_NAME}"
+          git push "https://x-access-token:${TRIVY_CHOCOLATEY_DEPLOY_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "HEAD:${GIT_REF_NAME}"
 
     # on windows latest, build and push the package to chocolatey.org and myget.org
   build-and-push:
@@ -55,9 +56,8 @@ jobs:
     needs: update
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          token: ${{ secrets.TRIVY_CHOCOLATEY_DEPLOY_TOKEN }}
           ref: main
           persist-credentials: false
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,29 +8,17 @@ on:
         required: false
         default: ''
 
-permissions:
-  contents: write
-  pull-requests: write
-  packages: write
-  actions: read
-  deployments: read
-  id-token: write
-  issues: write
-  discussions: read
-  pages: read
-  repository-projects: read
-  security-events: read
-  attestations: read # Added this
-  checks: write # Added this
-  statuses: write # Added
-
 jobs:
   # run the update script on ubuntu and push the changes to main branch
   update:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-2404-2core
+    permissions:
+      contents: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Set up Git
         run: |
@@ -39,32 +27,40 @@ jobs:
 
       - name: Set Trivy version from input
         id: set_version
+        env:
+          INPUT_VERSION: ${{ github.event.inputs.version }}
         run: |
           # Remove "v" prefix if present
-          incoming_version="${{ github.event.inputs.version }}"
+          incoming_version="${INPUT_VERSION}"
           echo "version=${incoming_version#v}" >> $GITHUB_OUTPUT
 
       - name: Run update script
+        env:
+          TRIVY_VERSION: ${{ steps.set_version.outputs.version }}
         run: |
-          ./scripts/update.sh "${{ steps.set_version.outputs.version }}"
+          ./scripts/update.sh "$TRIVY_VERSION"
 
       - name: Commit and push changes
+        env:
+          TRIVY_CHOCOLATEY_DEPLOY_TOKEN: ${{ secrets.TRIVY_CHOCOLATEY_DEPLOY_TOKEN }}
+          GIT_REF_NAME: ${{ github.ref_name }}
         run: |
           git add trivy.nuspec tools/chocolateyinstall.ps1
           git commit -m "Update package to latest version" || echo "No changes to commit"
-          git push origin HEAD:${{ github.ref_name }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          git push "https://x-access-token:${TRIVY_CHOCOLATEY_DEPLOY_TOKEN}@github.com/${{ github.repository }}.git" "HEAD:${GIT_REF_NAME}"
 
     # on windows latest, build and push the package to chocolatey.org and myget.org
   build-and-push:
     runs-on: windows-latest
     needs: update
+    permissions:
+      contents: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
-          ref: main   
+          ref: main
+          persist-credentials: false
 
       - name: pack the project
         run: |
@@ -73,4 +69,3 @@ jobs:
           choco push -s https://push.chocolatey.org/
         env:
           CHOCO_API_KEY: ${{ secrets.CHOCO_API_KEY }}
-


### PR DESCRIPTION
## Summary
- Fix zizmor security warnings: pin actions to SHA, add `persist-credentials: false` (`persist-credentials: true` for update job checkout that needs git push), move permissions to job level with least privilege
- Replace template injections in `run` blocks with environment variables
- Pass `TRIVY_CHOCOLATEY_DEPLOY_TOKEN` via `actions/checkout` instead of embedding in push URL
- Use `ubuntu-2404-2core` runner